### PR TITLE
compatible for mysql-connector-java-8.0.18

### DIFF
--- a/src/main/java/pl/exsio/nestedj/delegate/query/jdbc/JdbcNestedNodeInsertingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jdbc/JdbcNestedNodeInsertingQueryDelegate.java
@@ -26,6 +26,7 @@ import pl.exsio.nestedj.delegate.query.NestedNodeInsertingQueryDelegate;
 import pl.exsio.nestedj.model.NestedNode;
 
 import java.io.Serializable;
+import java.math.BigInteger;
 import java.sql.PreparedStatement;
 import java.sql.Types;
 
@@ -79,7 +80,8 @@ public class JdbcNestedNodeInsertingQueryDelegate<ID extends Serializable, N ext
             }
             return ps;
         }, keyHolder);
-        node.setId((ID) keyHolder.getKey());
+        Number key = keyHolder.getKey();
+        node.setId((ID) (key.getClass().equals(BigInteger.class) ? key.longValue() : keyHolder.getKey()));
     }
 
     @Override


### PR DESCRIPTION
in mysql-connector-java-8.0.18 ,the GENERATED_KEY will be always set to MysqlType.BIGINT_UNSIGNED
in file mysql/mysql-connector-java/8.0.18/mysql-connector-java-8.0.18-sources.jar!/com/mysql/cj/jdbc/StatementImpl.java:1414
   fields[0] = new Field("", "GENERATED_KEY", collationIndex, encoding, MysqlType.BIGINT_UNSIGNED, 20);