### PR TITLE
Update dependencies for JPA 3 support

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,8 @@
 NestedJ Changelog:
 
+- 6.0.0
+    - support JPA 3 (replace javax.persistence.* with jakarta.persistence.*)
+
 - 5.0.3
     - pass the node instance into generated JDBC key resolver
 

--- a/pom.xml
+++ b/pom.xml
@@ -13,31 +13,32 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.5.0</version>
+        <version>3.0.5</version>
         <relativePath />
     </parent>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <logback.version>1.2.3</logback.version>
-        <h2.version>1.4.200</h2.version>
+        <java.version>17</java.version>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <logback.version>1.4.6</logback.version>
+        <h2.version>2.1.214</h2.version>
     </properties>
 
     <dependencies>
 
         <dependency>
-            <groupId>org.hibernate.javax.persistence</groupId>
-            <artifactId>hibernate-jpa-2.1-api</artifactId>
-            <version>1.0.2.Final</version>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+            <version>3.1.0</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-jdbc</artifactId>
-            <version>5.3.7</version>
+            <version>6.0.7</version>
             <scope>provided</scope>
         </dependency>
 
@@ -77,7 +78,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.22.2</version>
+                <version>3.0.0</version>
                 <configuration>
                     <argLine>${argLine}</argLine>
                     <includes>
@@ -88,7 +89,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.9</version>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>pl.exsio</groupId>
     <artifactId>NestedJ</artifactId>
-    <version>5.0.4.RELEASE</version>
+    <version>6.0.0.RELEASE</version>
     <packaging>jar</packaging>
 
     <name>NestedJ</name>

--- a/src/main/java/pl/exsio/nestedj/DelegatingNestedNodeRepository.java
+++ b/src/main/java/pl/exsio/nestedj/DelegatingNestedNodeRepository.java
@@ -19,7 +19,12 @@
  */
 package pl.exsio.nestedj;
 
-import pl.exsio.nestedj.delegate.*;
+import pl.exsio.nestedj.delegate.NestedNodeHierarchyManipulator;
+import pl.exsio.nestedj.delegate.NestedNodeInserter;
+import pl.exsio.nestedj.delegate.NestedNodeMover;
+import pl.exsio.nestedj.delegate.NestedNodeRebuilder;
+import pl.exsio.nestedj.delegate.NestedNodeRemover;
+import pl.exsio.nestedj.delegate.NestedNodeRetriever;
 import pl.exsio.nestedj.ex.InvalidNodeException;
 import pl.exsio.nestedj.ex.InvalidParentException;
 import pl.exsio.nestedj.ex.RepositoryLockedException;

--- a/src/main/java/pl/exsio/nestedj/config/jdbc/factory/JdbcNestedNodeRepositoryFactory.java
+++ b/src/main/java/pl/exsio/nestedj/config/jdbc/factory/JdbcNestedNodeRepositoryFactory.java
@@ -23,8 +23,16 @@ package pl.exsio.nestedj.config.jdbc.factory;
 import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.NestedNodeRepository;
 import pl.exsio.nestedj.config.jdbc.JdbcNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.delegate.control.*;
-import pl.exsio.nestedj.delegate.query.jdbc.*;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeInserter;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeMover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRebuilder;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRemover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRetriever;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcNestedNodeInsertingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcNestedNodeMovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcNestedNodeRebuildingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcNestedNodeRemovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcNestedNodeRetrievingQueryDelegate;
 import pl.exsio.nestedj.lock.NoLock;
 import pl.exsio.nestedj.model.NestedNode;
 

--- a/src/main/java/pl/exsio/nestedj/config/jpa/JpaNestedNodeRepositoryConfiguration.java
+++ b/src/main/java/pl/exsio/nestedj/config/jpa/JpaNestedNodeRepositoryConfiguration.java
@@ -20,11 +20,11 @@
 
 package pl.exsio.nestedj.config.jpa;
 
+import jakarta.persistence.EntityManager;
 import pl.exsio.nestedj.config.jpa.discriminator.JpaTreeDiscriminator;
 import pl.exsio.nestedj.config.jpa.discriminator.MapJpaTreeDiscriminator;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.EntityManager;
 import java.io.Serializable;
 
 /**

--- a/src/main/java/pl/exsio/nestedj/config/jpa/discriminator/JpaTreeDiscriminator.java
+++ b/src/main/java/pl/exsio/nestedj/config/jpa/discriminator/JpaTreeDiscriminator.java
@@ -20,11 +20,11 @@
 
 package pl.exsio.nestedj.config.jpa.discriminator;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.List;
 

--- a/src/main/java/pl/exsio/nestedj/config/jpa/discriminator/MapJpaTreeDiscriminator.java
+++ b/src/main/java/pl/exsio/nestedj/config/jpa/discriminator/MapJpaTreeDiscriminator.java
@@ -20,11 +20,11 @@
 
 package pl.exsio.nestedj.config.jpa.discriminator;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/src/main/java/pl/exsio/nestedj/config/jpa/factory/JpaNestedNodeRepositoryFactory.java
+++ b/src/main/java/pl/exsio/nestedj/config/jpa/factory/JpaNestedNodeRepositoryFactory.java
@@ -23,8 +23,16 @@ package pl.exsio.nestedj.config.jpa.factory;
 import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.NestedNodeRepository;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.delegate.control.*;
-import pl.exsio.nestedj.delegate.query.jpa.*;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeInserter;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeMover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRebuilder;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRemover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRetriever;
+import pl.exsio.nestedj.delegate.query.jpa.JpaNestedNodeInsertingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jpa.JpaNestedNodeMovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jpa.JpaNestedNodeRebuildingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jpa.JpaNestedNodeRemovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.jpa.JpaNestedNodeRetrievingQueryDelegate;
 import pl.exsio.nestedj.lock.NoLock;
 import pl.exsio.nestedj.model.NestedNode;
 

--- a/src/main/java/pl/exsio/nestedj/config/mem/factory/InMemoryNestedNodeRepositoryFactory.java
+++ b/src/main/java/pl/exsio/nestedj/config/mem/factory/InMemoryNestedNodeRepositoryFactory.java
@@ -23,8 +23,16 @@ package pl.exsio.nestedj.config.mem.factory;
 import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.NestedNodeRepository;
 import pl.exsio.nestedj.config.mem.InMemoryNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.delegate.control.*;
-import pl.exsio.nestedj.delegate.query.mem.*;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeInserter;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeMover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRebuilder;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRemover;
+import pl.exsio.nestedj.delegate.control.QueryBasedNestedNodeRetriever;
+import pl.exsio.nestedj.delegate.query.mem.InMemoryNestedNodeInsertingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.mem.InMemoryNestedNodeMovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.mem.InMemoryNestedNodeRebuildingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.mem.InMemoryNestedNodeRemovingQueryDelegate;
+import pl.exsio.nestedj.delegate.query.mem.InMemoryNestedNodeRetrievingQueryDelegate;
 import pl.exsio.nestedj.lock.NoLock;
 import pl.exsio.nestedj.model.NestedNode;
 

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeInsertingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeInsertingQueryDelegate.java
@@ -20,13 +20,13 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.delegate.query.NestedNodeInsertingQueryDelegate;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 
 public class JpaNestedNodeInsertingQueryDelegate<ID extends Serializable, N extends NestedNode<ID>>

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeMovingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeMovingQueryDelegate.java
@@ -20,15 +20,15 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Expression;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.delegate.query.NestedNodeMovingQueryDelegate;
 import pl.exsio.nestedj.model.NestedNode;
 import pl.exsio.nestedj.model.NestedNodeInfo;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 
 import static pl.exsio.nestedj.model.NestedNode.ID;

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeQueryDelegate.java
@@ -20,14 +20,14 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.config.jpa.discriminator.JpaTreeDiscriminator;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Predicate;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRebuildingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRebuildingQueryDelegate.java
@@ -20,18 +20,22 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.delegate.query.NestedNodeRebuildingQueryDelegate;
 import pl.exsio.nestedj.model.NestedNode;
 
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaUpdate;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.List;
 
-import static pl.exsio.nestedj.model.NestedNode.*;
+import static pl.exsio.nestedj.model.NestedNode.ID;
+import static pl.exsio.nestedj.model.NestedNode.LEFT;
+import static pl.exsio.nestedj.model.NestedNode.LEVEL;
+import static pl.exsio.nestedj.model.NestedNode.PARENT_ID;
+import static pl.exsio.nestedj.model.NestedNode.RIGHT;
 
 public class JpaNestedNodeRebuildingQueryDelegate<ID extends Serializable, N extends NestedNode<ID>>
         extends JpaNestedNodeQueryDelegate<ID, N>

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRemovingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRemovingQueryDelegate.java
@@ -20,18 +20,26 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.delegate.query.NestedNodeRemovingQueryDelegate;
 import pl.exsio.nestedj.ex.InvalidNodeException;
 import pl.exsio.nestedj.model.NestedNode;
 import pl.exsio.nestedj.model.NestedNodeInfo;
 
-import javax.persistence.NoResultException;
-import javax.persistence.criteria.*;
 import java.io.Serializable;
 import java.util.Optional;
 
-import static pl.exsio.nestedj.model.NestedNode.*;
+import static pl.exsio.nestedj.model.NestedNode.ID;
+import static pl.exsio.nestedj.model.NestedNode.LEFT;
+import static pl.exsio.nestedj.model.NestedNode.LEVEL;
+import static pl.exsio.nestedj.model.NestedNode.PARENT_ID;
+import static pl.exsio.nestedj.model.NestedNode.RIGHT;
 
 public class JpaNestedNodeRemovingQueryDelegate<ID extends Serializable, N extends NestedNode<ID>>
         extends JpaNestedNodeQueryDelegate<ID, N>

--- a/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRetrievingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/jpa/JpaNestedNodeRetrievingQueryDelegate.java
@@ -20,21 +20,25 @@
 
 package pl.exsio.nestedj.delegate.query.jpa;
 
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.delegate.query.NestedNodeRetrievingQueryDelegate;
 import pl.exsio.nestedj.model.NestedNode;
 import pl.exsio.nestedj.model.NestedNodeInfo;
 
-import javax.persistence.NoResultException;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static pl.exsio.nestedj.model.NestedNode.*;
+import static pl.exsio.nestedj.model.NestedNode.ID;
+import static pl.exsio.nestedj.model.NestedNode.LEFT;
+import static pl.exsio.nestedj.model.NestedNode.LEVEL;
+import static pl.exsio.nestedj.model.NestedNode.PARENT_ID;
+import static pl.exsio.nestedj.model.NestedNode.RIGHT;
 
 public class JpaNestedNodeRetrievingQueryDelegate<ID extends Serializable, N extends NestedNode<ID>>
         extends JpaNestedNodeQueryDelegate<ID, N>

--- a/src/main/java/pl/exsio/nestedj/delegate/query/mem/InMemoryNestedNodeRetrievingQueryDelegate.java
+++ b/src/main/java/pl/exsio/nestedj/delegate/query/mem/InMemoryNestedNodeRetrievingQueryDelegate.java
@@ -31,7 +31,11 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static pl.exsio.nestedj.model.NestedNode.*;
+import static pl.exsio.nestedj.model.NestedNode.ID;
+import static pl.exsio.nestedj.model.NestedNode.LEFT;
+import static pl.exsio.nestedj.model.NestedNode.LEVEL;
+import static pl.exsio.nestedj.model.NestedNode.PARENT_ID;
+import static pl.exsio.nestedj.model.NestedNode.RIGHT;
 
 public class InMemoryNestedNodeRetrievingQueryDelegate<ID extends Serializable, N extends NestedNode<ID>>
         extends InMemoryNestedNodeQueryDelegate<ID, N>

--- a/src/test/java/pl/exsio/nestedj/RepositoryConfiguration.java
+++ b/src/test/java/pl/exsio/nestedj/RepositoryConfiguration.java
@@ -1,0 +1,112 @@
+package pl.exsio.nestedj;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import pl.exsio.nestedj.config.jdbc.JdbcNestedNodeRepositoryConfiguration;
+import pl.exsio.nestedj.config.jdbc.discriminator.TestJdbcTreeDiscriminator;
+import pl.exsio.nestedj.config.jdbc.factory.JdbcNestedNodeRepositoryFactory;
+import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
+import pl.exsio.nestedj.config.jpa.discriminator.TestJpaTreeDiscriminator;
+import pl.exsio.nestedj.config.jpa.factory.JpaNestedNodeRepositoryFactory;
+import pl.exsio.nestedj.config.mem.InMemoryNestedNodeRepositoryConfiguration;
+import pl.exsio.nestedj.config.mem.discriminator.TestInMemoryTreeDiscriminator;
+import pl.exsio.nestedj.config.mem.factory.InMemoryNestedNodeRepositoryFactory;
+import pl.exsio.nestedj.config.mem.lock.InMemoryLock;
+import pl.exsio.nestedj.delegate.query.jdbc.JdbcKeyHolder;
+import pl.exsio.nestedj.model.TestNode;
+import pl.exsio.nestedj.qualifier.Jdbc;
+import pl.exsio.nestedj.qualifier.Jpa;
+import pl.exsio.nestedj.qualifier.Mem;
+
+import javax.sql.DataSource;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
+@Configuration
+public class RepositoryConfiguration {
+
+    private static final AtomicLong ID = new AtomicLong();
+
+    public static final List<TestNode> IN_MEM_NODES = new ArrayList<>();
+
+    static {
+        IN_MEM_NODES.add(new TestNode(1000L, 1L, 0L, 16L, "a", null, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(2000L, 2L, 1L, 7L, "b", 1000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(3000L, 8L, 1L, 15L, "c", 1000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(4000L, 3L, 2L, 4L, "d", 2000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(5000L, 5L, 2L, 6L, "e", 2000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(6000L, 9L, 2L, 10L, "f", 3000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(7000L, 11L, 2L, 14L, "g", 3000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(8000L, 12L, 3L, 13L, "h", 7000L, "tree_1"));
+        IN_MEM_NODES.add(new TestNode(9000L, 1L, 0L, 16L, "a2", null, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(10000L, 2L, 1L, 7L, "b2", 9000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(11000L, 8L, 1L, 15L, "c2", 9000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(12000L, 3L, 2L, 4L, "d2", 10000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(13000L, 5L, 2L, 6L, "e2", 10000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(14000L, 9L, 2L, 10L, "f2", 11000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(15000L, 11L, 2L, 14L, "g2", 11000L, "tree_2"));
+        IN_MEM_NODES.add(new TestNode(16000L, 12L, 3L, 13L, "h2", 15000L, "tree_2"));
+    }
+
+    public static final InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> IN_MEM_CONFIG = inMemoryConfiguration();
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    @Jpa
+    public NestedNodeRepository<Long, TestNode> jpaRepository() {
+        JpaNestedNodeRepositoryConfiguration<Long, TestNode> configuration = new JpaNestedNodeRepositoryConfiguration<>(entityManager, TestNode.class, Long.class, new TestJpaTreeDiscriminator());
+        return JpaNestedNodeRepositoryFactory.create(configuration);
+    }
+
+    @Bean
+    @Jdbc
+    public NestedNodeRepository<Long, TestNode> jdbcRepository(DataSource dataSource) {
+        //ROW MAPPER FOR CREATING INSTANCES OF THE NODE OBJECT
+        RowMapper<TestNode> mapper = (resultSet, i) -> TestNode.fromResultSet(resultSet);
+
+        //TABLE NAME
+        String tableName = "nested_nodes";
+
+        // QUERY USED FOR INSERTING NEW NODES
+        String insertQuery = "insert into nested_nodes(id, tree_left, tree_level, tree_right, node_name, parent_id, discriminator) values(next value for SEQ,?,?,?,?,?,?)";
+
+        // INSERT QUERY VALUES PROVIDER, CONVERTS NODE OBJECT INTO AN OBJECT ARRAY
+        Function<TestNode, Object[]> insertValuesProvider = n -> new Object[]{n.getTreeLeft(), n.getTreeLevel(), n.getTreeRight(), n.getName(), n.getParentId(), n.getDiscriminator()};
+
+        // METHOD OF RETRIEVING GENERATED DATABASE PRIMARY KEYS
+        BiFunction<TestNode, JdbcKeyHolder, Long> generatedKeyResolver = (node, jdbcKeyHolder) -> jdbcKeyHolder.getKeyValueAs(Long.class);
+
+        JdbcNestedNodeRepositoryConfiguration<Long, TestNode> configuration = new JdbcNestedNodeRepositoryConfiguration<>(
+                new JdbcTemplate(dataSource), tableName, mapper, insertQuery, insertValuesProvider, generatedKeyResolver, new TestJdbcTreeDiscriminator()
+        );
+
+        configuration.setIdColumnName("id");
+        configuration.setParentIdColumnName("parent_id");
+        configuration.setLeftColumnName("tree_left");
+        configuration.setRightColumnName("tree_right");
+        configuration.setLevelColumnName("tree_level");
+
+        return JdbcNestedNodeRepositoryFactory.create(configuration);
+    }
+
+    @Bean
+    @Mem
+    public NestedNodeRepository<Long, TestNode> inMemoryRepository() {
+        return InMemoryNestedNodeRepositoryFactory.create(IN_MEM_CONFIG, new InMemoryLock<>(TestNode::getDiscriminator));
+    }
+
+    private static InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> inMemoryConfiguration() {
+        return new InMemoryNestedNodeRepositoryConfiguration<>(
+                ID::incrementAndGet, IN_MEM_NODES, new TestInMemoryTreeDiscriminator()
+        );
+    }
+}

--- a/src/test/java/pl/exsio/nestedj/TestConfiguration.java
+++ b/src/test/java/pl/exsio/nestedj/TestConfiguration.java
@@ -1,74 +1,22 @@
 package pl.exsio.nestedj;
 
+import jakarta.persistence.EntityManagerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.dao.annotation.PersistenceExceptionTranslationPostProcessor;
-import org.springframework.jdbc.core.JdbcTemplate;
-import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
 import org.springframework.transaction.PlatformTransactionManager;
-import pl.exsio.nestedj.config.jdbc.JdbcNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.config.jdbc.discriminator.TestJdbcTreeDiscriminator;
-import pl.exsio.nestedj.config.jdbc.factory.JdbcNestedNodeRepositoryFactory;
-import pl.exsio.nestedj.config.jpa.JpaNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.config.jpa.discriminator.TestJpaTreeDiscriminator;
-import pl.exsio.nestedj.config.jpa.factory.JpaNestedNodeRepositoryFactory;
-import pl.exsio.nestedj.config.mem.InMemoryNestedNodeRepositoryConfiguration;
-import pl.exsio.nestedj.config.mem.discriminator.TestInMemoryTreeDiscriminator;
-import pl.exsio.nestedj.config.mem.factory.InMemoryNestedNodeRepositoryFactory;
-import pl.exsio.nestedj.config.mem.lock.InMemoryLock;
-import pl.exsio.nestedj.delegate.query.jdbc.JdbcKeyHolder;
-import pl.exsio.nestedj.model.TestNode;
-import pl.exsio.nestedj.qualifier.Jdbc;
-import pl.exsio.nestedj.qualifier.Jpa;
-import pl.exsio.nestedj.qualifier.Mem;
 
-import javax.persistence.EntityManager;
-import javax.persistence.EntityManagerFactory;
-import javax.persistence.PersistenceContext;
 import javax.sql.DataSource;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.function.BiFunction;
-import java.util.function.Function;
 
 @Configuration
 public class TestConfiguration {
-
-    @PersistenceContext
-    EntityManager entityManager;
-
-    private static final AtomicLong ID = new AtomicLong();
-
-    public static final List<TestNode> IN_MEM_NODES = new ArrayList<>();
-
-    static {
-        IN_MEM_NODES.add(new TestNode(1000L, 1L, 0L, 16L, "a", null, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(2000L, 2L, 1L, 7L, "b", 1000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(3000L, 8L, 1L, 15L, "c", 1000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(4000L, 3L, 2L, 4L, "d", 2000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(5000L, 5L, 2L, 6L, "e", 2000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(6000L, 9L, 2L, 10L, "f", 3000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(7000L, 11L, 2L, 14L, "g", 3000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(8000L, 12L, 3L, 13L, "h", 7000L, "tree_1"));
-        IN_MEM_NODES.add(new TestNode(9000L, 1L, 0L, 16L, "a2", null, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(10000L, 2L, 1L, 7L, "b2", 9000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(11000L, 8L, 1L, 15L, "c2", 9000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(12000L, 3L, 2L, 4L, "d2", 10000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(13000L, 5L, 2L, 6L, "e2", 10000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(14000L, 9L, 2L, 10L, "f2", 11000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(15000L, 11L, 2L, 14L, "g2", 11000L, "tree_2"));
-        IN_MEM_NODES.add(new TestNode(16000L, 12L, 3L, 13L, "h2", 15000L, "tree_2"));
-    }
-
-    public static final InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> IN_MEM_CONFIG = inMemoryConfiguration();
 
     @Bean
     public DataSource dataSource() {
@@ -97,6 +45,7 @@ public class TestConfiguration {
         em.setPackagesToScan("pl.exsio");
         em.setJpaVendorAdapter(new HibernateJpaVendorAdapter());
         em.setJpaProperties(additionalProperties);
+
         return em;
     }
 
@@ -112,57 +61,4 @@ public class TestConfiguration {
     public PersistenceExceptionTranslationPostProcessor exceptionTranslation() {
         return new PersistenceExceptionTranslationPostProcessor();
     }
-
-    @Bean
-    @Jpa
-    public NestedNodeRepository<Long, TestNode> jpaRepository() {
-        JpaNestedNodeRepositoryConfiguration<Long, TestNode> configuration = new JpaNestedNodeRepositoryConfiguration<>(
-                entityManager, TestNode.class, Long.class, new TestJpaTreeDiscriminator()
-        );
-        return JpaNestedNodeRepositoryFactory.create(configuration);
-    }
-
-    @Bean
-    @Jdbc
-    public NestedNodeRepository<Long, TestNode> jdbcRepository(DataSource dataSource) {
-        //ROW MAPPER FOR CREATING INSTANCES OF THE NODE OBJECT
-        RowMapper<TestNode> mapper = (resultSet, i) -> TestNode.fromResultSet(resultSet);
-
-        //TABLE NAME
-        String tableName = "nested_nodes";
-
-        // QUERY USED FOR INSERTING NEW NODES
-        String insertQuery = "insert into nested_nodes(id, tree_left, tree_level, tree_right, node_name, parent_id, discriminator) values(next value for SEQ,?,?,?,?,?,?)";
-
-        // INSERT QUERY VALUES PROVIDER, CONVERTS NODE OBJECT INTO AN OBJECT ARRAY
-        Function<TestNode, Object[]> insertValuesProvider = n -> new Object[]{n.getTreeLeft(), n.getTreeLevel(), n.getTreeRight(), n.getName(), n.getParentId(), n.getDiscriminator()};
-
-        // METHOD OF RETRIEVING GENERATED DATABASE PRIMARY KEYS
-        BiFunction<TestNode, JdbcKeyHolder, Long> generatedKeyResolver = (node, jdbcKeyHolder) -> jdbcKeyHolder.getKeyValueAs(Long.class);
-
-        JdbcNestedNodeRepositoryConfiguration<Long, TestNode> configuration = new JdbcNestedNodeRepositoryConfiguration<>(
-                new JdbcTemplate(dataSource), tableName, mapper, insertQuery, insertValuesProvider, generatedKeyResolver, new TestJdbcTreeDiscriminator()
-        );
-
-        configuration.setIdColumnName("id");
-        configuration.setParentIdColumnName("parent_id");
-        configuration.setLeftColumnName("tree_left");
-        configuration.setRightColumnName("tree_right");
-        configuration.setLevelColumnName("tree_level");
-
-        return JdbcNestedNodeRepositoryFactory.create(configuration);
-    }
-
-    @Bean
-    @Mem
-    public NestedNodeRepository<Long, TestNode> inMemoryRepository() {
-        return InMemoryNestedNodeRepositoryFactory.create(IN_MEM_CONFIG, new InMemoryLock<>(TestNode::getDiscriminator));
-    }
-
-    private static InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> inMemoryConfiguration() {
-        return new InMemoryNestedNodeRepositoryConfiguration<>(
-                ID::incrementAndGet, IN_MEM_NODES, new TestInMemoryTreeDiscriminator()
-        );
-    }
-
 }

--- a/src/test/java/pl/exsio/nestedj/base/FunctionalNestedjTest.java
+++ b/src/test/java/pl/exsio/nestedj/base/FunctionalNestedjTest.java
@@ -27,13 +27,14 @@ package pl.exsio.nestedj.base;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
 import pl.exsio.nestedj.DelegatingNestedNodeRepository;
+import pl.exsio.nestedj.RepositoryConfiguration;
 import pl.exsio.nestedj.TestConfiguration;
 import pl.exsio.nestedj.model.TestNode;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@ContextConfiguration(classes = {TestConfiguration.class})
+@ContextConfiguration(classes = {TestConfiguration.class, RepositoryConfiguration.class})
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.NONE)
 public abstract class FunctionalNestedjTest {
 

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryInsertingTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryInsertingTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryInsertingTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryInsertingTest extends NestedNodeRepositoryInsertingTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryMovingTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryMovingTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryMovingTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryMovingTest extends NestedNodeRepositoryMovingTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRebuildingTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRebuildingTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryRebuildingTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryRebuildingTest extends NestedNodeRepositoryRebuildingTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRemovingTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRemovingTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryRemovingTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryRemovingTest extends NestedNodeRepositoryRemovingTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRetrievingTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryRetrievingTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryRetrievingTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryRetrievingTest extends NestedNodeRepositoryRetrievingTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryTest.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaNestedNodeRepositoryTest.java
@@ -23,6 +23,8 @@
  */
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,9 +32,6 @@ import pl.exsio.nestedj.DelegatingNestedNodeRepository;
 import pl.exsio.nestedj.base.NestedNodeRepositoryTest;
 import pl.exsio.nestedj.model.TestNode;
 import pl.exsio.nestedj.qualifier.Jpa;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 
 @Transactional
 public class JpaNestedNodeRepositoryTest extends NestedNodeRepositoryTest {

--- a/src/test/java/pl/exsio/nestedj/jpa/JpaTestHelper.java
+++ b/src/test/java/pl/exsio/nestedj/jpa/JpaTestHelper.java
@@ -1,12 +1,11 @@
 package pl.exsio.nestedj.jpa;
 
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Root;
 import pl.exsio.nestedj.base.TestHelper;
 import pl.exsio.nestedj.model.TestNode;
-
-import javax.persistence.EntityManager;
-import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.Root;
 
 public class JpaTestHelper implements TestHelper {
 

--- a/src/test/java/pl/exsio/nestedj/mem/InMemoryTestHelper.java
+++ b/src/test/java/pl/exsio/nestedj/mem/InMemoryTestHelper.java
@@ -1,6 +1,6 @@
 package pl.exsio.nestedj.mem;
 
-import pl.exsio.nestedj.TestConfiguration;
+import pl.exsio.nestedj.RepositoryConfiguration;
 import pl.exsio.nestedj.base.TestHelper;
 import pl.exsio.nestedj.config.mem.InMemoryNestedNodeRepositoryConfiguration;
 import pl.exsio.nestedj.model.TestNode;
@@ -10,7 +10,7 @@ import java.util.stream.Collectors;
 
 public class InMemoryTestHelper implements TestHelper {
 
-    private final InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> config = TestConfiguration.IN_MEM_CONFIG;
+    private final InMemoryNestedNodeRepositoryConfiguration<Long, TestNode> config = RepositoryConfiguration.IN_MEM_CONFIG;
 
     @Override
     public TestNode findNode(String symbol) {
@@ -33,10 +33,10 @@ public class InMemoryTestHelper implements TestHelper {
         config.getNodes().stream()
                 .filter(n -> n.getDiscriminator()
                         .equals("tree_1")).forEach(n -> {
-            n.setTreeLevel(0L);
-            n.setTreeLeft(0L);
-            n.setTreeRight(0L);
-        });
+                    n.setTreeLevel(0L);
+                    n.setTreeLeft(0L);
+                    n.setTreeRight(0L);
+                });
     }
 
     @Override
@@ -59,6 +59,6 @@ public class InMemoryTestHelper implements TestHelper {
 
     public void rollback() {
         config.getNodes().clear();
-        config.getNodes().addAll(TestConfiguration.IN_MEM_NODES.stream().map(TestNode::copy).collect(Collectors.toList()));
+        config.getNodes().addAll(RepositoryConfiguration.IN_MEM_NODES.stream().map(TestNode::copy).collect(Collectors.toList()));
     }
 }

--- a/src/test/java/pl/exsio/nestedj/model/TestNode.java
+++ b/src/test/java/pl/exsio/nestedj/model/TestNode.java
@@ -23,13 +23,14 @@
  */
 package pl.exsio.nestedj.model;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.SequenceGenerator;
-import javax.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Objects;


### PR DESCRIPTION
- Migration to JPA 3 specification (https://dzone.com/articles/upgrade-guide-to-spring-boot-3-for-spring-data-jpa-3-and-querydsl-5)
- Dependencies versions update